### PR TITLE
Remove redundant background colour declaration from body in main CSS …

### DIFF
--- a/css/10-main.css
+++ b/css/10-main.css
@@ -74,13 +74,10 @@ div.page-header {
 
 body {
     font-family: 'Proxima Nova';
-    background-color: #ffffff;
     line-height: 1.5;
     font-weight: 400;
 }
 
-.wrapper,
-.main,
 .layout-wrapper.login-page {
     background-color: #ffffff !important;
 }


### PR DESCRIPTION
Update the theme to make login page background white while the rest is grey as usual.
hotfix 0.5.1